### PR TITLE
Better support for multi-line queries

### DIFF
--- a/database/mariadb/mariadb.go
+++ b/database/mariadb/mariadb.go
@@ -41,7 +41,7 @@ func (db *Database) ParseBlocks(rawBlocs chan []string) {
 				if line[0] == '#' {
 					db.parseMariaDBHeader(line, &q)
 				} else {
-					q.Query = q.Query + line
+					q.Query = strings.TrimSpace(q.Query + " " + line)
 				}
 			}
 			db.WaitingList <- q

--- a/database/mariadb/mariadb.go
+++ b/database/mariadb/mariadb.go
@@ -41,7 +41,11 @@ func (db *Database) ParseBlocks(rawBlocs chan []string) {
 				if line[0] == '#' {
 					db.parseMariaDBHeader(line, &q)
 				} else {
-					q.Query = strings.TrimSpace(q.Query + " " + line)
+					if strings.HasSuffix(q.Query,";") || q.Query == "" {
+						q.Query = q.Query + line
+					}else{
+						q.Query = q.Query + " " + line
+					}
 				}
 			}
 			db.WaitingList <- q

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -40,7 +40,11 @@ func (db *Database) ParseBlocks(rawBlocs chan []string) {
 				if line[0] == '#' {
 					db.parseMySQLHeader(line, &q)
 				} else {
-					q.Query = strings.TrimSpace(q.Query + " " + line)
+					if strings.HasSuffix(q.Query,";") || q.Query == "" {
+						q.Query = q.Query + line
+					}else{
+						q.Query = q.Query + " " + line
+					}
 				}
 			}
 			db.WaitingList <- q

--- a/database/mysql/mysql.go
+++ b/database/mysql/mysql.go
@@ -40,7 +40,7 @@ func (db *Database) ParseBlocks(rawBlocs chan []string) {
 				if line[0] == '#' {
 					db.parseMySQLHeader(line, &q)
 				} else {
-					q.Query = q.Query + line
+					q.Query = strings.TrimSpace(q.Query + " " + line)
 				}
 			}
 			db.WaitingList <- q


### PR DESCRIPTION
Sometimes the slow log includes multi-line queries. I've noticed on multiple occasions that these can get squashed incorrectly when recompiling them.

For example:
```
SELECT col1 AS c1
FROM table1 AS t1;
```
might get turned into:
```
SELECT col1 AS c1FROM table1 AS t1;
```

This PR includes a small fix to avoid that and produces a functional query, i.e.
```
SELECT col1 AS c1 FROM table1 AS t1;
```